### PR TITLE
[kilted] Update deprecated call to ament_target_dependencies

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,7 +27,7 @@ set(COMPONENT_AMENT_DEPENDENCIES
 add_library(${PROJECT_NAME} SHARED src/adaptive_component.cpp)
 target_compile_definitions(${PROJECT_NAME}
   PRIVATE "COMPOSITION_BUILDING_DLL")
-ament_target_dependencies(${PROJECT_NAME} ${COMPONENT_AMENT_DEPENDENCIES})
+target_link_libraries(${PROJECT_NAME} PUBLIC ${COMPONENT_AMENT_DEPENDENCIES})
 rclcpp_components_register_nodes(${PROJECT_NAME} "composition::AdaptiveComponent")
 set(node_plugins "${node_plugins}composition::AdaptiveComponent;$<TARGET_FILE:adaptive_component>\n")
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,7 +27,10 @@ set(COMPONENT_AMENT_DEPENDENCIES
 add_library(${PROJECT_NAME} SHARED src/adaptive_component.cpp)
 target_compile_definitions(${PROJECT_NAME}
   PRIVATE "COMPOSITION_BUILDING_DLL")
-target_link_libraries(${PROJECT_NAME} PUBLIC ${COMPONENT_AMENT_DEPENDENCIES})
+target_link_libraries(${PROJECT_NAME} PUBLIC
+  rclcpp::rclcpp
+  rclcpp_components::component
+  rclcpp_components::component_manager)
 rclcpp_components_register_nodes(${PROJECT_NAME} "composition::AdaptiveComponent")
 set(node_plugins "${node_plugins}composition::AdaptiveComponent;$<TARGET_FILE:adaptive_component>\n")
 


### PR DESCRIPTION
As of the ROS 2 Kilted release [`ament_target_dependencies` is deprecated.](https://docs.ros.org/en/kilted/Releases/Release-Kilted-Kaiju.html#ament-target-dependencies-is-deprecated)

This PR updates the syntax. Caution should be used to ensure that the target branch is not used for other ROS 2 distros.

Note: This PR was generated by a bot script, but using the simple pattern matching of the [`ros_glint`](https://github.com/MetroRobots/ros_glint) library. No LLMs were used.
